### PR TITLE
Correct product name in banner

### DIFF
--- a/script/motd.sh
+++ b/script/motd.sh
@@ -7,7 +7,7 @@ echo "==> Customizing message of the day"
 MOTD_FILE=/etc/motd
 BANNER_WIDTH=64
 PLATFORM_RELEASE=$(sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/redhat-release)
-PLATFORM_MSG=$(printf 'Oracle Enterprise Linux %s' "$PLATFORM_RELEASE")
+PLATFORM_MSG=$(printf 'Oracle Linux %s' "$PLATFORM_RELEASE")
 BUILT_MSG=$(printf 'built %s' $(date +%Y-%m-%d))
 printf '%0.1s' "-"{1..64} > ${MOTD_FILE}
 printf '\n' >> ${MOTD_FILE}


### PR DESCRIPTION
Change "Oracle Enterprise Linux" to "Oracle Linux".  Product hasn't been called Oracle Enterprise Linux for a long time.
