### PR TITLE
fix that proxy env variables entry is not added to /etc/sudoers

### DIFF
--- a/http/ks7-desktop.cfg
+++ b/http/ks7-desktop.cfg
@@ -82,5 +82,5 @@ echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 cp /etc/sudoers /etc/sudoers.orig
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 # keep proxy settings through sudo
-echo "Defaults env_keep += "HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY NO_PROXY" >> /etc/sudoers
+echo "Defaults env_keep += \"HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY NO_PROXY\"" >> /etc/sudoers
 %end

--- a/http/ks7.cfg
+++ b/http/ks7.cfg
@@ -85,5 +85,5 @@ echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 cp /etc/sudoers /etc/sudoers.orig
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 # keep proxy settings through sudo
-echo "Defaults env_keep += "HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY NO_PROXY" >> /etc/sudoers
+echo "Defaults env_keep += \"HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY NO_PROXY\"" >> /etc/sudoers
 %end


### PR DESCRIPTION
In the OL7 kickstart file %post setion,  the proxy related environment variables are not properly added to /etc/sudoers, this patch fixes the shell syntax error.
