### PR TITLE
Typo: Replacing "Ubuntu" with "Oracle Linux" on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Parallels requires that the
 [Parallels Virtualization SDK for Mac](http://www.parallels.com/downloads/desktop)
 be installed as an additional preqrequisite.
 
-We make use of JSON files containing user variables to build specific versions of Ubuntu.
+We make use of JSON files containing user variables to build specific versions of Oracle Linux.
 You tell `packer` to use a specific user variable file via the `-var-file=` command line
 option.  This will override the default options on the core `oraclelinux.json` packer template,
 which builds Oracle Linux 6.7 by default.


### PR DESCRIPTION
Just a little typo :smirk: