### PR TITLE
Add support for Packer 1.1: set expect_disconnect to true.

### DIFF
--- a/oraclelinux.json
+++ b/oraclelinux.json
@@ -130,7 +130,8 @@
         "script/motd.sh",
         "script/cleanup.sh"
       ],
-      "type": "shell"
+      "type": "shell",
+      "expect_disconnect": "true"
     }
   ],
   "variables": {
@@ -165,4 +166,3 @@
     "vmware_guest_os_type": "oraclelinux-64"
   }
 }
-


### PR DESCRIPTION
Otherwise, update.sh will fail because the reboot disconnects and then packer bails out (see https://github.com/hashicorp/packer/blob/master/CHANGELOG.md#backwards-incompatibilities).